### PR TITLE
fix page size for 'spike' RISC-V platform

### DIFF
--- a/platform/spike/getpagesize.c
+++ b/platform/spike/getpagesize.c
@@ -4,5 +4,5 @@ int
 getpagesize(void)
 {
 
-	return 8092;
+	return 4096;
 }


### PR DESCRIPTION
1) The old 8092 was a typo for 8192
2) As of the latest draft supervisor spec (http://riscv.org/spec/riscv-privileged-spec-v1.7.pdf), which is implemented in the spike simulator, the page size is 4KiB. This is also reflected in the new_privileged_isa branch of the Linux kernel riscv port https://github.com/riscv/riscv-linux/blob/new_privileged_isa/arch/riscv/include/asm/page.h
